### PR TITLE
Fix path to dacpac in nerd-dinner-db image

### DIFF
--- a/ch03/ch03-nerd-dinner-db/Dockerfile
+++ b/ch03/ch03-nerd-dinner-db/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR C:\init
 COPY Initialize-Database.ps1 .
 CMD powershell ./Initialize-Database.ps1 -sa_password $env:sa_password -data_path $env:data_path -Verbose
 
-COPY --from=builder C:\src\NerdDinner.Database\bin\Debug\NerdDinner.Database.dacpac .
+COPY --from=builder C:\docker\NerdDinner.Database.dacpac .


### PR DESCRIPTION
The nerd-dinner-db image build is broken because the output path of the debug configuration for the database project is set to `C:\docker`, but the dockerfile is copying from the bin folder under the original source location.