### PR TITLE
Update db image to a specific tag for SQL Server 2016

### DIFF
--- a/ch03/ch03-nerd-dinner-db/Dockerfile
+++ b/ch03/ch03-nerd-dinner-db/Dockerfile
@@ -8,7 +8,7 @@ RUN msbuild NerdDinner.Database.sqlproj `
     /p:SqlServerRedistPath="C:\Microsoft.Data.Tools.Msbuild.10.0.61026\lib\net40"
 
 # db image
-FROM microsoft/mssql-server-windows-express
+FROM microsoft/mssql-server-windows-express:2016-sp1
 
 ENV ACCEPT_EULA="Y" `
     DATA_PATH="C:\data" `


### PR DESCRIPTION
Initialize-Database.ps1 has hard coded path to C:\Program Files (x86)\Microsoft SQL Server\130\DAC\bin\SqlPackage.exe which doesn't exist in later versions of SQL Server which are pulled-down by an untagged image. Have confirmed that this fixes the 'path not found' error when using untagged image.