### PR TITLE
Update Dockerfiles to use mcr.microsoft.com

### DIFF
--- a/ch02/ch02-dotnet-helloworld/Dockerfile
+++ b/ch02/ch02-dotnet-helloworld/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809
 
 WORKDIR /src
 COPY src/ .

--- a/ch02/ch02-dotnet-helloworld/Dockerfile.multistage
+++ b/ch02/ch02-dotnet-helloworld/Dockerfile.multistage
@@ -1,5 +1,5 @@
 # build stage
-FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809 AS builder
 
 WORKDIR /src
 COPY src/ .
@@ -8,7 +8,7 @@ USER ContainerAdministrator
 RUN dotnet restore && dotnet publish
 
 # final image stage
-FROM microsoft/dotnet:2.2-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/runtime:2.2-nanoserver-1809
 
 WORKDIR /dotnetapp
 COPY --from=builder /src/bin/Debug/netcoreapp2.2/publish .

--- a/ch02/ch02-dotnet-helloworld/Dockerfile.slim
+++ b/ch02/ch02-dotnet-helloworld/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/runtime:2.2-nanoserver-1809
 
 WORKDIR /dotnetapp
 COPY ./src/bin/Debug/netcoreapp2.2/publish .

--- a/ch02/ch02-hitcount-website/Dockerfile
+++ b/ch02/ch02-hitcount-website/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809 AS builder
 
 WORKDIR C:\src
 COPY src .
@@ -8,7 +8,7 @@ USER ContainerAdministrator
 RUN dotnet restore && dotnet publish
 
 # app image
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-nanoserver-1809
 
 EXPOSE 80
 WORKDIR C:\dotnetapp

--- a/ch02/ch02-nerd-dinner/Dockerfile
+++ b/ch02/ch02-nerd-dinner/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src\NerdDinner
 COPY src\NerdDinner\packages.config .

--- a/ch03/ch03-iis-healthcheck/Dockerfile
+++ b/ch03/ch03-iis-healthcheck/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src
 COPY src\Healthcheck.WebApi.sln .

--- a/ch03/ch03-nerd-dinner-homepage/Dockerfile
+++ b/ch03/ch03-nerd-dinner-homepage/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809 AS builder
 
 WORKDIR C:\src\NerdDinner.Homepage
 COPY src\NerdDinner.Homepage\NerdDinner.Homepage.csproj .
@@ -9,7 +9,7 @@ COPY src\NerdDinner.Homepage .
 RUN dotnet publish
 
 # app image
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-nanoserver-1809
 
 WORKDIR C:\dotnetapp
 ENV NERD_DINNER_URL="/home/find"

--- a/ch03/ch03-nerd-dinner-web/Dockerfile
+++ b/ch03/ch03-nerd-dinner-web/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src\NerdDinner
 COPY src\NerdDinner\packages.config .

--- a/ch03/ch03-nerd-dinner-web/Dockerfile.v2
+++ b/ch03/ch03-nerd-dinner-web/Dockerfile.v2
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src\NerdDinner
 COPY src\NerdDinner\packages.config .

--- a/ch05/ch05-nerd-dinner-api/Dockerfile
+++ b/ch05/ch05-nerd-dinner-api/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1809
 
 EXPOSE 80
 WORKDIR /dinner-api

--- a/ch05/ch05-nerd-dinner-builder/Dockerfile
+++ b/ch05/ch05-nerd-dinner-builder/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src
 COPY src .

--- a/ch05/ch05-nerd-dinner-index-handler/Dockerfile
+++ b/ch05/ch05-nerd-dinner-index-handler/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.1-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1-nanoserver-1809
 
 CMD ["dotnet", "NerdDinner.MessageHandlers.IndexDinner.dll"]
 

--- a/ch06/ch06-nerd-dinner-db/Dockerfile
+++ b/ch06/ch06-nerd-dinner-db/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # add SSDT build tools

--- a/ch07/ch07-nerd-dinner-api/Dockerfile
+++ b/ch07/ch07-nerd-dinner-api/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1809
 
 EXPOSE 80
 WORKDIR /dinner-api

--- a/ch07/ch07-nerd-dinner-homepage/Dockerfile
+++ b/ch07/ch07-nerd-dinner-homepage/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809 AS builder
 
 WORKDIR C:\src\NerdDinner.Homepage
 COPY src\NerdDinner.Homepage\NerdDinner.Homepage.csproj .
@@ -9,7 +9,7 @@ COPY src\NerdDinner.Homepage .
 RUN dotnet publish
 
 # app image
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-nanoserver-1809
 
 WORKDIR C:\dotnetapp
 ENV NERD_DINNER_URL="/home/find"

--- a/ch09/ch09-resource-check/Dockerfile
+++ b/ch09/ch09-resource-check/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src
 COPY src\DockerOnWindows.ResourceCheck.sln .

--- a/ch10/ch10-nerd-dinner/docker/nerd-dinner-api/Dockerfile
+++ b/ch10/ch10-nerd-dinner/docker/nerd-dinner-api/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.1-sdk-nanoserver-1809 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1-nanoserver-1809 AS builder
 
 WORKDIR C:\src
 COPY src\NerdDinner.Core\NerdDinner.Core.csproj .\NerdDinner.Core\
@@ -11,7 +11,7 @@ COPY src\NerdDinner.DinnerApi .\NerdDinner.DinnerApi
 RUN dotnet publish -c Release -o C:\dinner-api .\NerdDinner.DinnerApi\NerdDinner.DinnerApi.csproj
 
 # api
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1809
 
 EXPOSE 80
 WORKDIR /dinner-api

--- a/ch10/ch10-nerd-dinner/docker/nerd-dinner-db/Dockerfile
+++ b/ch10/ch10-nerd-dinner/docker/nerd-dinner-db/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # add SSDT build tools

--- a/ch10/ch10-nerd-dinner/docker/nerd-dinner-e2e-tests/Dockerfile
+++ b/ch10/ch10-nerd-dinner/docker/nerd-dinner-e2e-tests/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src\NerdDinner.EndToEndTests
 COPY src\NerdDinner.EndToEndTests\packages.config .

--- a/ch10/ch10-nerd-dinner/docker/nerd-dinner-homepage/Dockerfile
+++ b/ch10/ch10-nerd-dinner/docker/nerd-dinner-homepage/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809 AS builder
 
 WORKDIR C:\src\NerdDinner.Homepage
 COPY src\NerdDinner.Homepage\NerdDinner.Homepage.csproj .
@@ -9,7 +9,7 @@ COPY src\NerdDinner.Homepage .
 RUN dotnet publish
 
 # app image
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-nanoserver-1809
 
 WORKDIR C:\dotnetapp
 ENV NERD_DINNER_URL="/home/find"

--- a/ch10/ch10-nerd-dinner/docker/nerd-dinner-index-handler/Dockerfile
+++ b/ch10/ch10-nerd-dinner/docker/nerd-dinner-index-handler/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.1-sdk-nanoserver-1809 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1-nanoserver-1809 AS builder
 
 WORKDIR C:\src
 COPY src\NerdDinner.Core\NerdDinner.Core.csproj .\NerdDinner.Core\
@@ -13,7 +13,7 @@ COPY src\NerdDinner.MessageHandlers.IndexDinner .\NerdDinner.MessageHandlers.Ind
 RUN dotnet publish -c Release -o C:\index-handler .\NerdDinner.MessageHandlers.IndexDinner\NerdDinner.MessageHandlers.IndexDinner.csproj
 
 # index-handler
-FROM microsoft/dotnet:2.1-runtime-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1-nanoserver-1809
 
 CMD ["dotnet", "NerdDinner.MessageHandlers.IndexDinner.dll"]
 

--- a/ch10/ch10-nerd-dinner/docker/nerd-dinner-save-handler/Dockerfile
+++ b/ch10/ch10-nerd-dinner/docker/nerd-dinner-save-handler/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src
 COPY src\NerdDinner.Core\NerdDinner.Core.csproj .\NerdDinner.Core\

--- a/ch10/ch10-nerd-dinner/docker/nerd-dinner-web/Dockerfile
+++ b/ch10/ch10-nerd-dinner/docker/nerd-dinner-web/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src
 COPY src\NerdDinner.Core\NerdDinner.Core.csproj .\NerdDinner.Core\

--- a/ch11/ch11-api-with-metrics/Dockerfile
+++ b/ch11/ch11-api-with-metrics/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 AS builder
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019 AS builder
 
 WORKDIR C:\src\ApiWithMetrics
 COPY src\ApiWithMetrics\packages.config .

--- a/ch11/ch11-webapi-vscode/src/WebApi.NetCore/Dockerfile
+++ b/ch11/ch11-webapi-vscode/src/WebApi.NetCore/Dockerfile
@@ -1,11 +1,11 @@
 #Depending on the operating system of the host machines(s) that will build or run the containers, the image specified in the FROM statement may need to be changed.
 #For more information, please see https://aka.ms/containercompat
 
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1809 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-nanoserver-1809 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809 AS build
 ARG CONFIGURATION=Release
 WORKDIR /src
 COPY ["WebApi.NetCore.csproj", "./"]


### PR DESCRIPTION
Recently, while looking at the sample code, there was a problem that the Dockerfile could not receive some base images. Upon investigation, it seemed that the Dockerfile needed to be modified.

* microsoft/dotnet:2.2-sdk-nanoserver-1809 -> mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809
* microsoft/dotnet:2.2-runtime-nanoserver-1809 -> mcr.microsoft.com/dotnet/core/runtime:2.2-nanoserver-1809
* microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1809 -> mcr.microsoft.com/dotnet/core/aspnet:2.2-nanoserver-1809
* microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1809 -> mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1809
* microsoft/dotnet:2.1-sdk-nanoserver-1809 -> mcr.microsoft.com/dotnet/core/sdk:2.1-nanoserver-1809
* microsoft/dotnet:2.1-runtime-nanoserver-1809 -> mcr.microsoft.com/dotnet/core/runtime:2.1-nanoserver-1809
* microsoft/dotnet-framework:4.7.2-sdk-windowsservercore-ltsc2019 -> mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-ltsc2019